### PR TITLE
Use default values for names and categories

### DIFF
--- a/wp-content/themes/illdy-child/layout/js/translations_page.js
+++ b/wp-content/themes/illdy-child/layout/js/translations_page.js
@@ -358,6 +358,9 @@ var TranslationsPage = (function(window, $) {
       subcontents.forEach(function(subcontent) {
         if (subcontent) {
           var category = subcontent.dataset.category.trim() || 'other';
+          if (!(category in containers)) {
+              category = 'other';
+          }
           containers[category].appendChild(subcontent);
         }
       });

--- a/wp-content/themes/illdy-child/layout/js/translations_page.js
+++ b/wp-content/themes/illdy-child/layout/js/translations_page.js
@@ -332,7 +332,7 @@ var TranslationsPage = (function(window, $) {
         subcontentRow.setAttribute('data-category', subcontent.category);
 
         var subcontentTitle = create('p', 'subcontent-title');
-        subcontentTitle.innerText = subcontent.name;
+        subcontentTitle.innerText = subcontent.name || subcontent.code || "Other";
         subcontentRow.appendChild(subcontentTitle);
 
         var linkContainer = create('div', 'subcontent-links');


### PR DESCRIPTION
This change fixes two bugs:

- Resources without a category will now be categorized as "other" (instead of crashing)
- Resources without a name will now be displayed as their code, or "Other" (instead of "undefined")