### PR TITLE
Add 'topics' category, don't show empty zip contents

### DIFF
--- a/wp-content/themes/illdy-child/layout/js/translations_page.js
+++ b/wp-content/themes/illdy-child/layout/js/translations_page.js
@@ -463,6 +463,7 @@ var TranslationsPage = (function(window, $) {
         'bible-ot': create('div', 'ot-subcontent-container'),
         'bible-nt': create('div', 'nt-subcontent-container'),
         'obs': create('div', 'obs-subcontent-container'),
+        'topics': create('div', 'topics-subcontent-container'),
         'other': create('div', 'other-subcontent-container'),
       };
 
@@ -495,6 +496,12 @@ var TranslationsPage = (function(window, $) {
         obsContainerTitle.innerText = 'Chapters';
         accordion.appendChild(obsContainerTitle);
         accordion.appendChild(containers['obs']);
+      }
+      if (containers['topics'].childNodes.length) {
+        var topicsContainerTitle = create('h5', 'topics-subcontent-title');
+        topicsContainerTitle.innerText = 'Topics';
+        accordion.appendChild(topicsContainerTitle);
+        accordion.appendChild(containers['topics']);
       }
       if (containers['other'].childNodes.length) {
         var otherContainerTitle = create('h5', 'other-subcontent-title');

--- a/wp-content/themes/illdy-child/layout/js/translations_page.js
+++ b/wp-content/themes/illdy-child/layout/js/translations_page.js
@@ -422,7 +422,9 @@ var TranslationsPage = (function(window, $) {
           var linkEl = create('a', className);
           linkEl.innerText = link.format;
           if (link.format === 'zip') {
-            linkEl.innerText += ' (' + link.zipContent + ')';
+            if (link.zipContent) {
+              linkEl.innerText += ' (' + link.zipContent + ')';
+            }
           }
           if (link.quality) {
             var qualitySpan = create('i', 'quality');


### PR DESCRIPTION
This PR makes two changes to the BIEL Translations page:

- Add support for new "Topics" category, used by review guides and similar content
- Zip files with unspecified contents now show as "zip" instead of "zip ()"