### PR TITLE
Normalize accented characters for searching

### DIFF
--- a/wp-content/themes/illdy-child/layout/js/translations_page.js
+++ b/wp-content/themes/illdy-child/layout/js/translations_page.js
@@ -225,10 +225,20 @@ var TranslationsPage = (function(window, $) {
 
     this.filterLangs = function(list, filter, resource_filter, translationsData) {
         var searchText = filter.value.toUpperCase();
+
+        // "Normalize" search string for searching by replacing accented characters with plain ones
+        // Adapted from: https://stackoverflow.com/a/37511463
+        searchText = searchText.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+
         var items = list.getElementsByTagName('li');
         for (i = 0; i < items.length; i++) {
             var item = items[i];
             var langText = item.innerText.toUpperCase();
+
+            // "Normalize" language names for searching by replacing accented characters with plain ones
+            // Adapted from: https://stackoverflow.com/a/37511463
+            langText = langText.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+
             var displayItem = false;
             // Check for name match
             if (langText.indexOf(searchText) > -1) {


### PR DESCRIPTION
When searching for text, normalize the accented characters so that e.g. 'Nandeva' will match 'Ñandeva'.
